### PR TITLE
funcsigs 1.0.0 not available on anaconda cloud for python 3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - flask-login ==0.2.11
     - flask-swagger ==0.2.13
     - flask-wtf ==0.12
-    - funcsigs ==1.0.0  # [py<33]
+    - funcsigs ==1.0.0   [py<33]
     - future >=0.15.0,<0.16
     - gitpython >=2.0.2
     - gunicorn >=19.3.0,<19.4.0


### PR DESCRIPTION
The reason of this PR is just to make sure that packages that are used are all in conda-forge for python 2.7 and 3.5. Wondering why this line was commented out in the first place. 