### PR TITLE
Add airflow-with-aws

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -154,6 +154,12 @@ outputs:
   #   test:
   #     imports:
   #       - airflow.lineage.backend.atlas
+  - name: {{ name }}-with-aws
+    requirements:
+      run:
+        - {{ pin_subpackage(name, max_pin='x.x.x.x.x.x') }}
+        - boto3 >=1.12.0,<2.0.0
+        - watchtower 0.7.3
 
   - name: {{ name }}-with-azure_blob_storage
     requirements:


### PR DESCRIPTION
will be blocked until i get [watchtower 0.7.3](https://github.com/conda-forge/watchtower-feedstock/pull/9) merged