### PR TITLE
Constrain httpx >=0.17.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}
@@ -64,7 +64,9 @@ outputs:
         - google-re2 >=1.0
         - python-graphviz >=0.12
         - gunicorn >=20.1.0
-        - httpx
+        # add a constraint to not pick up old httpx without HTTPTransport
+        # https://github.com/conda-forge/airflow-feedstock/issues/121
+        - httpx >=0.17.0
         - importlib-metadata >=1.7  # [py<39]
         - importlib-resources >=5.2  # [py<39]
         - itsdangerous >=2.0


### PR DESCRIPTION
See https://github.com/conda-forge/airflow-feedstock/issues/121

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

closes #121 