### PR TITLE
Switch to source from PyPI

### DIFF
--- a/recipe/install_airflow.sh
+++ b/recipe/install_airflow.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-# dev/hatch_build.py was purposefully removed from the release but we need it
+# dev/ was purposefully removed from the release but we need some files from it
 mkdir -p dev
 for file in hatch_build.py airflow_pre_installed_providers.txt
 do

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,18 @@
 {% set name = "airflow" %}
+{% set pypi_name = "apache-airflow" %}
 {% set version = "2.8.1" %}
-{% set sha256 = "4d0a1e4373854fb442663c8cf4db84db6f11836fe76bbaf0f3e6b06a8adc3ef1" %}
 
 package:
   name: {{ name|lower }}-split
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/apache/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/{{ pypi_name[0] }}/{{ pypi_name }}/apache_airflow-{{ version }}.tar.gz
+  sha256: 7443d82b790886c5ec137a8fdb94d672e33e81336713ca7320b4a1bbad443a9c
 
 build:
   skip: true  # [win or py>=312]
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}
@@ -527,7 +526,6 @@ about:
   license: Apache-2.0
   license_file:
     - LICENSE
-    - NOTICE
     - 3rd-party-licenses/LICENSE-bootstrap3-typeahead.txt
     - 3rd-party-licenses/LICENSE-bootstrap.txt
     - 3rd-party-licenses/LICENSE-d3js.txt


### PR DESCRIPTION
This source has the `airflow/www/static/dist` files that are missing from the release source and not getting built automatically.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
